### PR TITLE
fix: prefix stream/web import with `node:`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Run test WPT test against our impl [#109]
 - File name are now casted to string [#109]
 - Slicing in the middle of multiple parts added more bytes than what what it should have [#109]
+- Prefixed `stream/web` import with `node:` to allow easier static analysis detection of Node built-ins [#122]
 
 ## v3.1.2
 

--- a/streams.cjs
+++ b/streams.cjs
@@ -4,7 +4,7 @@ const POOL_SIZE = 65536;
 
 if (!globalThis.ReadableStream) {
   try {
-    Object.assign(globalThis, require('stream/web'))
+    Object.assign(globalThis, require('node:stream/web'))
   } catch (error) {
 		// TODO: Remove when only supporting node >= 16.5.0
     Object.assign(globalThis, require('web-streams-polyfill/dist/ponyfill.es2018.js'))

--- a/test.js
+++ b/test.js
@@ -390,7 +390,7 @@ test('returns a readable stream', t => {
 
 test('checking instanceof blob#stream', async t => {
 	// eslint-disable-next-line node/no-unsupported-features/es-syntax
-	const {ReadableStream} = await import('stream/web').catch(_ => import('web-streams-polyfill/dist/ponyfill.es2018.js'));
+	const {ReadableStream} = await import('node:stream/web').catch(_ => import('web-streams-polyfill/dist/ponyfill.es2018.js'));
 	const stream = new File([], '').stream();
 	t.true(stream instanceof ReadableStream);
 });


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## The purpose of this PR is:

Making it more obvious that `stream/web` is a Node built-in. Since we upgraded to `node-fetch` 3.0 final our deploys are failing on Netlify (https://github.com/netlify/zip-it-and-ship-it/issues/743). I'm hoping this would be part of a solution

## This is what had to change:

Add `node:` prefix

## This is what like reviewers to know:

[This is a supported syntax for importing core modules](https://nodejs.org/api/modules.html#modules_core_modules). I believe the `node:` prefix is only available on Node 16. However, since `stream/web` is only available on Node 16 as well, I don't think that should be an issue. It does skip the require cache, which might cause some small performance loss - if the user's application is importing `stream/web` elsewhere I believe this will cause a new instance to be imported

I might wait to merge this until seeing what the reviewers of the detection package think about the idea as well (https://github.com/dependents/node-precinct/pull/88). However, I thought I'd at least raise it here to see whether you'd be amenable to the idea.

-------------------------------------------------------------------------------------------------

<!-- Mark what you have done, Remove unnecessary ones. Add new tasks that may fit (like TODO's) -->
- [X] I prefixed the PR-title with `docs: `, `fix(area): `, `feat(area): ` or `breaking(area): `
- [X] I updated ./CHANGELOG.md with a link to this PR or Issue
- [ ] I updated the README.md
- [ ] I Added unit test(s)

-------------------------------------------------------------------------------------------------

<!-- Add a `- fix #_NUMBER_` line for every Issue this PR solves. Do not comma separate them 
- fix #000
-->