### PR TITLE
fix(deps): remove deprecated node-domexception dependency

### DIFF
--- a/from.js
+++ b/from.js
@@ -8,7 +8,6 @@ import {
 import { basename, sep, join } from 'node:path'
 import { tmpdir } from 'node:os'
 import process from 'node:process'
-import DOMException from 'node-domexception'
 
 import { File } from './file.js'
 import { Blob } from './index.js'

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "node-fetch"
     ],
     "engines": {
-        "node": ">=16.7"
+        "node": ">=17"
     },
     "author": "Jimmy Wärting <jimmy@warting.se> (https://jimmy.warting.se)",
     "license": "MIT",
@@ -47,8 +47,5 @@
             "type": "paypal",
             "url": "https://paypal.me/jimmywarting"
         }
-    ],
-    "dependencies": {
-        "node-domexception": "^1.0.0"
-    }
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "node-fetch"
     ],
     "engines": {
-        "node": ">=17"
+        "node": ">=20"
     },
     "author": "Jimmy Wärting <jimmy@warting.se> (https://jimmy.warting.se)",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fetch-blob",
-    "version": "4.0.0",
+    "version": "5.0.0",
     "description": "Blob & File implementation in Node.js, originally from node-fetch.",
     "main": "index.js",
     "type": "module",


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## The purpose of this PR is:
Remove dependency `node-domexception` which is deprecated in favor of Node.js native `DOMException` (available since Node.js 17).

## This is what had to change:
- Bump minimum Node.js version from `>=16.7` to `>=17`
- Remove `node-domexception` from dependencies

## This is what reviewers should know:
- All existing tests pass except one unrelated `Float16Array` test failure


-------------------------------------------------------------------------------------------------

<!-- Mark what you have done with [x], Remove unnecessary ones. Add new tasks that may fit (like TODO's) -->
- [x] I prefixed the PR-title with `docs: `, `fix(area): `, `feat(area): ` or `breaking(area): `
- [x] I updated the README.md
- [x] I Added unit test(s)

-------------------------------------------------------------------------------------------------

<!-- Add a `- fix #_NUMBER_` line for every Issue this PR solves. Do not comma separate them -->
- fix #175 
